### PR TITLE
Custom normals export is now controlled by an option in Scene properties

### DIFF
--- a/io_xplane2blender/xplane_props.py
+++ b/io_xplane2blender/xplane_props.py
@@ -844,6 +844,13 @@ class XPlaneSceneSettings(bpy.types.PropertyGroup):
         default = False
     )
 
+    exportCustomNormals = bpy.props.BoolProperty (
+        attr = "exportCustomNormals",
+        name = "Export Custom Normals (2.77+)",
+        description = "If checked, custom split normals will be exported. Only works in Blender 2.77 and above",
+        default = False
+    )
+
     version = bpy.props.EnumProperty(
         attr = "version",
         name = "X-Plane Version",

--- a/io_xplane2blender/xplane_types/xplane_mesh.py
+++ b/io_xplane2blender/xplane_types/xplane_mesh.py
@@ -36,6 +36,8 @@ class XPlaneMesh():
     def collectXPlaneObjects(self, xplaneObjects):
         debug = getDebug()
 
+        exportCustomNormals = bpy.context.scene.xplane.exportCustomNormals
+
         def getSortKey(xplaneObject):
             return xplaneObject.name
 
@@ -106,7 +108,7 @@ class XPlaneMesh():
                             # get the vertice from original mesh
                             v = mesh.vertices[vindex]
                             co = v.co
-                            ns=f['norms'][2-i]
+                            ns = f['norms'][2-i] if exportCustomNormals else v.normal
 
                             if f['original_face'].use_smooth: # use smoothed vertex normal
                                 vert = [

--- a/io_xplane2blender/xplane_ui.py
+++ b/io_xplane2blender/xplane_ui.py
@@ -171,6 +171,11 @@ def scene_layout(self, scene):
     row = layout.row()
     row.label("Will automaticly create and use corrected normal textures. (Recommended)", icon = "INFO")
 
+    row = layout.row();
+    row.prop(scene.xplane, "exportCustomNormals")
+    row = layout.row();
+    row.label("Will use custom split normals when exporting (Blender 2.77 and above)", icon = "INFO")
+
     row = layout.row()
 
     if scene.xplane.exportMode == 'layers':


### PR DESCRIPTION
To avoid confusion when using the script with the earlier versions of Blender, custom normals are only exported if the "Export Custom Normals" option is checked; reverting to the old behavior otherwise.