### PR TITLE
222 semantic file path assert equals

### DIFF
--- a/io_xplane2blender/xplane_types/xplane_header.py
+++ b/io_xplane2blender/xplane_types/xplane_header.py
@@ -405,6 +405,8 @@ class XPlaneHeader():
         texpath = os.path.relpath(texpath, exportdir)
 
         return texpath
+        #Replace any \ separators if you're on Windows. For other platforms this does nothing
+        return texpath.replace("\\","/")
 
     # Method: _getCanonicalTexturePath
     # Returns normalized (canonical) path to texture

--- a/io_xplane2blender/xplane_types/xplane_header.py
+++ b/io_xplane2blender/xplane_types/xplane_header.py
@@ -404,7 +404,6 @@ class XPlaneHeader():
 
         texpath = os.path.relpath(texpath, exportdir)
 
-        return texpath
         #Replace any \ separators if you're on Windows. For other platforms this does nothing
         return texpath.replace("\\","/")
 


### PR DESCRIPTION
Fixes test cases where being on different platforms would result in different OBJ files, because Windows uses "\" by default. This broke the unit tester and creates false differences since the paths are semantically the same.