### PR TITLE
Fix #242: Filter out sibling and parent bone data

### DIFF
--- a/io_xplane2blender/xplane_types/xplane_bone.py
+++ b/io_xplane2blender/xplane_types/xplane_bone.py
@@ -74,20 +74,28 @@ class XPlaneBone():
 
         #check for animation
         if bone:
+            name = bone.name
             logger.info("\t\t checking animations of %s:%s" % (blenderObject.name, bone.name))
         else:
+            name = blenderObject.name
             logger.info("\t\t checking animations of %s" % blenderObject.name)
+
 
         animationData = blenderObject.animation_data
 
         # bone animation data resides in the armature objects .data block
         if bone:
             animationData = blenderObject.data.animation_data
+            logger.info("\t\t bone.keys = %s" % bone.keys())
 
         if (animationData != None and animationData.action != None and len(animationData.action.fcurves) > 0):
             logger.info("\t\t animation found")
             #check for dataref animation by getting fcurves with the dataref group
             for fcurve in animationData.action.fcurves:
+                if fcurve.data_path.find('["' + name + '"]') == -1 and bone:
+                    logger.info("\t\t name not found on %s, skipping" % fcurve.data_path)
+                    continue
+
                 logger.info("\t\t checking FCurve %s Group: %s" % (fcurve.data_path, fcurve.group))
                 #if (fcurve.group != None and fcurve.group.name == groupName): # since 2.61 group names are not set so we have to check the datapath
                 if ('xplane.datarefs' in fcurve.data_path):


### PR DESCRIPTION
I discovered a bug (#242) where armatures with more than one bone were occasionally behaving erratically. 

Upon investigation it was because of the way `XPlaneBone` extracted `FCurve` data from the armature. It was just looping over every `FCurve` in the armature's animation data. This would cause child and sibling bones to mix their animation data when exporting.


My fix was to just look at the name of the `FCurve` and make sure it has the name of the bone. I don't know if this is a valid fix since there is no contract that that the `FCurve` always contains the correct name but I don't know of any cleaner way to check the association.

What would be nice is if each bone had a reference to its `FCurve`s, but I think this would be a blender level change.

It would be great if someone who knows more about X2B or Blender could check this and let me know if there is a cleaner way to do it.